### PR TITLE
Fix SD card init error in bootloader

### DIFF
--- a/FdsKey_bootloader/Core/Src/main.c
+++ b/FdsKey_bootloader/Core/Src/main.c
@@ -144,7 +144,7 @@ int main(void)
   // Init SD card and FAT
   if (HAL_GPIO_ReadPin(SD_DTCT_GPIO_Port, SD_DTCT_Pin))
     show_error_screen("No SD card", 1);
-  r = SD_init();
+  r = SD_init_try_speed();
   if (r != HAL_OK)
     show_error_screen("Can't init SD card", 1);
   fr = f_mount(&FatFs, "", 1);

--- a/FdsKey_bootloader/FATFS/Target/user_diskio.c
+++ b/FdsKey_bootloader/FATFS/Target/user_diskio.c
@@ -82,7 +82,7 @@ DSTATUS USER_initialize (
 )
 {
   /* USER CODE BEGIN INIT */
-  HAL_StatusTypeDef r = SD_init();
+  HAL_StatusTypeDef r = SD_init_try_speed();
   if (r == HAL_OK)
     return 0;
   else


### PR DESCRIPTION
Use `SD_init_try_speed` in BL. Looks like maybe this change was accidentally left out of the bootloader tree.

There is one more difference I did not change: The `sdcard.c` in the bootloader tree tries one more clock divider. I'm not sure which version you want to keep or if you really want the bootloader and main code to differ in that way.

```$ diff -u FdsKey/Core/Src/sdcard.c FdsKey_bootloader/Core/Src/sdcard.c
--- FdsKey/Core/Src/sdcard.c    2023-06-08 00:59:28.401983600 -0700
+++ FdsKey_bootloader/Core/Src/sdcard.c 2023-06-16 01:47:54.364697700 -0700
@@ -345,6 +345,11 @@
     return r;
   SD_SPI_PORT.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
   HAL_SPI_Init(&SD_SPI_PORT);
+  r = SD_init();
+  if (r == HAL_OK)
+    return r;
+  SD_SPI_PORT.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;
+  HAL_SPI_Init(&SD_SPI_PORT);
   return SD_init();
 }
```